### PR TITLE
devtools: Encapsulate long string actor creation better.

### DIFF
--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -8,10 +8,11 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
-#[derive(Clone)]
+const INITIAL_LENGTH: usize = 500;
+
 pub struct LongStringActor {
-    pub name: String,
-    pub full_string: String,
+    name: String,
+    full_string: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -70,17 +71,17 @@ impl Actor for LongStringActor {
 }
 
 impl LongStringActor {
-    pub fn new(registry: &crate::actor::ActorRegistry, full_string: String) -> Self {
+    pub fn new(registry: &ActorRegistry, full_string: String) -> Self {
         let name = registry.new_name("longStringActor");
         LongStringActor { name, full_string }
     }
 
-    pub fn long_string_obj(actor: String, length: usize, initial: String) -> LongStringObj {
+    pub fn long_string_obj(&self) -> LongStringObj {
         LongStringObj {
             type_: "longString".to_string(),
-            actor,
-            length,
-            initial,
+            actor: self.name.clone(),
+            length: self.full_string.len(),
+            initial: self.full_string.chars().take(INITIAL_LENGTH).collect(),
         }
     }
 }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -357,17 +357,12 @@ impl Actor for NetworkEventActor {
 
                     if Self::is_text_mime(&mime_type) {
                         let full_str = String::from_utf8_lossy(body).to_string();
-                        let initial: String = full_str.chars().take(500).collect();
 
                         // Queue a LongStringActor for this body
-                        let long_string_actor = LongStringActor::new(registry, full_str.clone());
-                        registry.register_later(Box::new(long_string_actor.clone()));
+                        let long_string_actor = LongStringActor::new(registry, full_str);
+                        let long_string_obj = long_string_actor.long_string_obj();
+                        registry.register_later(Box::new(long_string_actor));
 
-                        let long_string_obj = LongStringActor::long_string_obj(
-                            long_string_actor.name(),
-                            full_str.chars().count(),
-                            initial,
-                        );
                         ResponseContentObj {
                             mime_type,
                             text: serde_json::to_value(long_string_obj).unwrap(),


### PR DESCRIPTION
The code that creates a new long string actor shouldn't need to know any details about how the actor values are produced.